### PR TITLE
Fix issue #3: GitHub pages is empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
-        "@chakra-ui/react": "^3.19.1",
+        "@chakra-ui/react": "^2.10.9",
         "@chakra-ui/theme": "^3.4.6",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -43,75 +43,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@ark-ui/react": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@ark-ui/react/-/react-5.9.1.tgz",
-      "integrity": "sha512-CPJtUy20x1kUAQ+8iPbgpq/RmqlF1Pfx91+8nHnYbR2dYI4mNKnxT8m7TGkoWT72W+P8YKYUehFJOPvspZqG2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@internationalized/date": "3.8.0",
-        "@zag-js/accordion": "1.12.2",
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/angle-slider": "1.12.2",
-        "@zag-js/auto-resize": "1.12.2",
-        "@zag-js/avatar": "1.12.2",
-        "@zag-js/carousel": "1.12.2",
-        "@zag-js/checkbox": "1.12.2",
-        "@zag-js/clipboard": "1.12.2",
-        "@zag-js/collapsible": "1.12.2",
-        "@zag-js/collection": "1.12.2",
-        "@zag-js/color-picker": "1.12.2",
-        "@zag-js/color-utils": "1.12.2",
-        "@zag-js/combobox": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/date-picker": "1.12.2",
-        "@zag-js/date-utils": "1.12.2",
-        "@zag-js/dialog": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/editable": "1.12.2",
-        "@zag-js/file-upload": "1.12.2",
-        "@zag-js/file-utils": "1.12.2",
-        "@zag-js/floating-panel": "1.12.2",
-        "@zag-js/focus-trap": "1.12.2",
-        "@zag-js/highlight-word": "1.12.2",
-        "@zag-js/hover-card": "1.12.2",
-        "@zag-js/i18n-utils": "1.12.2",
-        "@zag-js/listbox": "1.12.2",
-        "@zag-js/menu": "1.12.2",
-        "@zag-js/number-input": "1.12.2",
-        "@zag-js/pagination": "1.12.2",
-        "@zag-js/pin-input": "1.12.2",
-        "@zag-js/popover": "1.12.2",
-        "@zag-js/presence": "1.12.2",
-        "@zag-js/progress": "1.12.2",
-        "@zag-js/qr-code": "1.12.2",
-        "@zag-js/radio-group": "1.12.2",
-        "@zag-js/rating-group": "1.12.2",
-        "@zag-js/react": "1.12.2",
-        "@zag-js/select": "1.12.2",
-        "@zag-js/signature-pad": "1.12.2",
-        "@zag-js/slider": "1.12.2",
-        "@zag-js/splitter": "1.12.2",
-        "@zag-js/steps": "1.12.2",
-        "@zag-js/switch": "1.12.2",
-        "@zag-js/tabs": "1.12.2",
-        "@zag-js/tags-input": "1.12.2",
-        "@zag-js/time-picker": "1.12.2",
-        "@zag-js/timer": "1.12.2",
-        "@zag-js/toast": "1.12.2",
-        "@zag-js/toggle": "1.12.2",
-        "@zag-js/toggle-group": "1.12.2",
-        "@zag-js/tooltip": "1.12.2",
-        "@zag-js/tour": "1.12.2",
-        "@zag-js/tree-view": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -168,6 +99,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.27.1",
@@ -396,10 +334,25 @@
       }
     },
     "node_modules/@chakra-ui/anatomy": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.4.tgz",
-      "integrity": "sha512-fFIYN7L276gw0Q7/ikMMlZxP7mvnjRaWJ7f3Jsf9VtDOi6eAYIBRrhQe6+SZ0PGmoOkRaBc7gSE5oeIbgFFyrw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.6.tgz",
+      "integrity": "sha512-TjmjyQouIZzha/l8JxdBZN1pKZTj7sLpJ0YkFnQFyqHcbfWggW9jKWzY1E0VBnhtFz/xF3KC6UAVuZVSJx+y0g==",
       "license": "MIT"
+    },
+    "node_modules/@chakra-ui/hooks": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.4.5.tgz",
+      "integrity": "sha512-601fWfHE2i7UjaxK/9lDLlOni6vk/I+04YDbM0BrelJy+eqxdlOmoN8Z6MZ3PzFh7ofERUASor+vL+/HaCaZ7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/utils": "2.2.5",
+        "@zag-js/element-size": "0.31.1",
+        "copy-to-clipboard": "3.3.3",
+        "framesync": "6.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
     },
     "node_modules/@chakra-ui/icons": {
       "version": "2.2.4",
@@ -412,59 +365,62 @@
       }
     },
     "node_modules/@chakra-ui/react": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.19.1.tgz",
-      "integrity": "sha512-NxmJUIxy9Uqs2/2WbMBQjU2TdK2AdCO1AfoMz/kI3ia4ig1FJ5NzXRGSEnTGrdOfrqL8GJp4ztbPfc4yspqWsQ==",
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.10.9.tgz",
+      "integrity": "sha512-lhdcgoocOiURwBNR3L8OioCNIaGCZqRfuKioLyaQLjOanl4jr0PQclsGb+w0cmito252vEWpsz2xRqF7y+Flrw==",
       "license": "MIT",
       "dependencies": {
-        "@ark-ui/react": "5.9.1",
-        "@emotion/is-prop-valid": "1.3.1",
-        "@emotion/serialize": "1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "1.2.0",
-        "@emotion/utils": "1.4.2",
-        "@pandacss/is-valid-prop": "0.53.6",
-        "csstype": "3.1.3",
-        "fast-safe-stringify": "2.1.1"
+        "@chakra-ui/hooks": "2.4.5",
+        "@chakra-ui/styled-system": "2.12.4",
+        "@chakra-ui/theme": "3.4.9",
+        "@chakra-ui/utils": "2.2.5",
+        "@popperjs/core": "^2.11.8",
+        "@zag-js/focus-visible": "^0.31.1",
+        "aria-hidden": "^1.2.3",
+        "react-fast-compare": "3.2.2",
+        "react-focus-lock": "^2.9.6",
+        "react-remove-scroll": "^2.5.7"
       },
       "peerDependencies": {
         "@emotion/react": ">=11",
+        "@emotion/styled": ">=11",
+        "framer-motion": ">=4.0.0",
         "react": ">=18",
         "react-dom": ">=18"
       }
     },
     "node_modules/@chakra-ui/styled-system": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.12.0.tgz",
-      "integrity": "sha512-zoqLw1I2y4GlZ0LDoyw8o0JjoDOW6u0IwFPAoHuw0UMbP8glHUGvwEL1STug/i/GzBKw83yoF6ae41HIQvhMww==",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.12.4.tgz",
+      "integrity": "sha512-oa07UG7Lic5hHSQtGRiMEnYjuhIa8lszyuVhZjZqR2Ap3VMF688y1MVPJ1pK+8OwY5uhXBgVd5c0+rI8aBZlwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@chakra-ui/utils": "2.2.2",
+        "@chakra-ui/utils": "2.2.5",
         "csstype": "^3.1.2"
       }
     },
     "node_modules/@chakra-ui/theme": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.6.tgz",
-      "integrity": "sha512-ZwFBLfiMC3URwaO31ONXoKH9k0TX0OW3UjdPF3EQkQpYyrk/fm36GkkzajjtdpWEd7rzDLRsQjPmvwNaSoNDtg==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.9.tgz",
+      "integrity": "sha512-GAom2SjSdRWTcX76/2yJOFJsOWHQeBgaynCUNBsHq62OafzvELrsSHDUw0bBqBb1c2ww0CclIvGilPup8kXBFA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.3.4",
-        "@chakra-ui/theme-tools": "2.2.6",
-        "@chakra-ui/utils": "2.2.2"
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/theme-tools": "2.2.9",
+        "@chakra-ui/utils": "2.2.5"
       },
       "peerDependencies": {
         "@chakra-ui/styled-system": ">=2.8.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.6.tgz",
-      "integrity": "sha512-3UhKPyzKbV3l/bg1iQN9PBvffYp+EBOoYMUaeTUdieQRPFzo2jbYR0lNCxqv8h5aGM/k54nCHU2M/GStyi9F2A==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.9.tgz",
+      "integrity": "sha512-PcbYL19lrVvEc7Oydy//jsy/MO/rZz1DvLyO6AoI+bI/+Kwz9WfOKsspbulEhRg5COayE0R/IZPsskXZ7Mp4bA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.3.4",
-        "@chakra-ui/utils": "2.2.2",
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/utils": "2.2.5",
         "color2k": "^2.0.2"
       },
       "peerDependencies": {
@@ -472,9 +428,9 @@
       }
     },
     "node_modules/@chakra-ui/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-jUPLT0JzRMWxpdzH6c+t0YMJYrvc5CLericgITV3zDSXblkfx3DsYXqU11DJTSGZI9dUKzM1Wd0Wswn4eJwvFQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-KTBCK+M5KtXH6p54XS39ImQUMVtAx65BoZDoEms3LuObyTo1+civ1sMm4h3nRT320U6H5H7D35WnABVQjqU/4g==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash.mergewith": "4.6.9",
@@ -502,12 +458,6 @@
         "source-map": "^0.5.7",
         "stylis": "4.2.0"
       }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
@@ -1215,31 +1165,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT"
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1304,24 +1229,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/number": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.1.tgz",
-      "integrity": "sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1410,10 +1317,15 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pandacss/is-valid-prop": {
-      "version": "0.53.6",
-      "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-0.53.6.tgz",
-      "integrity": "sha512-TgWBQmz/5j/oAMjavqJAjQh1o+yxhYspKvepXPn4lFhAN3yBhilrw9HliAkvpUr0sB2CkJ2BYMpFXbAJYEocsA=="
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.41.0",
@@ -1695,15 +1607,6 @@
         "win32"
       ]
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1764,9 +1667,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.17.tgz",
+      "integrity": "sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==",
       "license": "MIT"
     },
     "node_modules/@types/lodash.mergewith": {
@@ -1785,10 +1688,10 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
-      "integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
-      "dev": true,
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
+      "integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1824,826 +1727,26 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
-    "node_modules/@zag-js/accordion": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.12.2.tgz",
-      "integrity": "sha512-EoTVa4Tppgp3bfaOhBrgSyOUeeGWFmXn2gGT9AuMq0x46sc4xw5IsRveYPHwBzifrTE3tAKVIZBA5rFoTaA43Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/anatomy": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.12.2.tgz",
-      "integrity": "sha512-avPmEivu4QFAICJ4rogt9ZFMp4trwva11jQfIAHXYDDL6YoF58z69129eLuyVSuSjEQ9EOzxg+fxMjXH2xm7yQ==",
-      "license": "MIT"
-    },
-    "node_modules/@zag-js/angle-slider": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/angle-slider/-/angle-slider-1.12.2.tgz",
-      "integrity": "sha512-pd62FEJZmnJAjrUcV5J+IayRGrUuMp90EPf5Sd2nwlBoxarmz6mSYr8jpeAPSjeT73rYkph8D+USM4qc3xHanQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/rect-utils": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/aria-hidden": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.12.2.tgz",
-      "integrity": "sha512-xhtgOYYzTztQNKmROpEjkbeVbbvqm70595kOVsQOPhaWKVBK4EySLhYEeTRCjLmK9jVwUWQAETISqyA2za9AfQ==",
-      "license": "MIT"
-    },
-    "node_modules/@zag-js/auto-resize": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.12.2.tgz",
-      "integrity": "sha512-LhkL85yuLsIS4t3+XjpJZmZb1hAG9pTf1JIRNQ5HtmoCiOf/wxX73SJdOeQBKfzm1w8Hz5C6skNSxgJuYo0Wzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/avatar": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.12.2.tgz",
-      "integrity": "sha512-zAgxzx6dzH2Kds0hGgPBGm1wWjwurn3CojdID6V9awHq+u5aDf/HIKDOIdjaNlTPdXtBeWrzJaKQiqHmNGrong==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/carousel": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.12.2.tgz",
-      "integrity": "sha512-5nxNzar7wwGJIMV2As2/a2HLju8s7XahaLuq8BCiLQlhDN0N894Y2JazXm1gCthS7FdMlxa433G7bjYrxMYw9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/scroll-snap": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/checkbox": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/checkbox/-/checkbox-1.12.2.tgz",
-      "integrity": "sha512-9kkmo9lz0eQcIkEmPCbevv6cl5fNRhMvyGKgsCENbaeU2VpntYlF8eRn81S2/7naE0JpXCGq+7jMgHHjKhNHeA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-visible": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/clipboard": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/clipboard/-/clipboard-1.12.2.tgz",
-      "integrity": "sha512-lANTh8XOPmEiFUgVfd8+ORdpHC7grPImB3X71Kj1a2hfvEDLI/INop379aNsncboCdJkWp0slRzyquHSOgfaTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/collapsible": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.12.2.tgz",
-      "integrity": "sha512-vmYHRhWex2LkcNRvg3oAzhmnF5gR+vBLfRpP8vu3hsX4zAn6GS2GggVeH3prBnNAIsErA4ech29BzqAhp5xeLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/collection": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.12.2.tgz",
-      "integrity": "sha512-IVEXMBguC/QljCT6L5DsrSYUWvi+SWacGweDm12fckMEwPBpGOxv+dR0yqcjaeNEDuTkT0WHeZaWI/0TNV533g==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/color-picker": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/color-picker/-/color-picker-1.12.2.tgz",
-      "integrity": "sha512-HXE5iyQaM7KOyu1SXcVJdDqtuZ+GRpdP8CaJVTz4RkBqaFBd3jrMVr3eW/Hv5N3b7v3vsfGHXXLchte+tcVpnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/color-utils": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/color-utils": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/color-utils/-/color-utils-1.12.2.tgz",
-      "integrity": "sha512-ZfshXAqaHhgo8tieADVZ99AoUTn3IK+K8UZ2cYmiTHkrmXGkXQUGysdqsCYkPE/nzC3CmIXLK4LPj5tHYJVydQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/combobox": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.12.2.tgz",
-      "integrity": "sha512-PaNSh27057I+kwrfyUWSo0K54hwWK6oP+d0NPez9mrQRABj1wVbPc8R5ouseZqI6LL0zRGc4oZB7Inq1o5usWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/aria-hidden": "1.12.2",
-        "@zag-js/collection": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.12.2.tgz",
-      "integrity": "sha512-deECf4FGOSjmD+f3Y116D9dHYs4NP87GBtQgQQ9oCXP8SOCR3A9gSkUGcFU+cQq2tNA5I1F9KqUElc0fDYfh4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/date-picker": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.12.2.tgz",
-      "integrity": "sha512-su741tKtQgGQ6KwTE2+oOIgGezOq/cQQyIWXUF0jkEyvsSPio06LRel/cvho3QO9oMzR6W7pus5fMOQPPO9Omw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/date-utils": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/live-region": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      },
-      "peerDependencies": {
-        "@internationalized/date": ">=3.0.0"
-      }
-    },
-    "node_modules/@zag-js/date-utils": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.12.2.tgz",
-      "integrity": "sha512-FTpwgfk+xoHLQEHEVYO1yoXwgNdwTVlA4XX/IhSqj+3KOTXIu60SymX63fE/rqWzayXmH5m8doP7LGW758u1mg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@internationalized/date": ">=3.0.0"
-      }
-    },
-    "node_modules/@zag-js/dialog": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.12.2.tgz",
-      "integrity": "sha512-Eqs/fpFc9wzYQQne4VOh8qivxuJyEcUR+MO/onTSFVV/AaJfXXowsXk7kAzcQrNzbvLn+yuTOCYFlh4QsPlLXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/aria-hidden": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-trap": "1.12.2",
-        "@zag-js/remove-scroll": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/dismissable": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.12.2.tgz",
-      "integrity": "sha512-YIuUx+9mzzf2x9gWayt6T2e2N6nyrlBqzkJfwXJ9R3wEz065AW5X1PeKGGrvYlojPok1yNAaDq6mFL6Rqb6IVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/interact-outside": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
     "node_modules/@zag-js/dom-query": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.12.2.tgz",
-      "integrity": "sha512-UvFHQbkX6zscdYnMYc5TnrV/FkKlb4dMombXO2rD20NStU9gxb7uYtq91aPSO2x7aVCwNWuPWRb1nFAYGFBOvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/types": "1.12.2"
-      }
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
+      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg==",
+      "license": "MIT"
     },
-    "node_modules/@zag-js/editable": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/editable/-/editable-1.12.2.tgz",
-      "integrity": "sha512-kL6LulJKFOU8riW4tzM5QhAm6I6+zjfw28FjhOny7r4Mtc0HRQUJfh6WzlBcq72fqxvvf8J2OuVq2yeWPE9XBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/interact-outside": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/file-upload": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.12.2.tgz",
-      "integrity": "sha512-JOjW4JGwRKVpDjZcLCU/qEAVNeUJbb9hYdmAvIAtBmf34VL3q17jsCKDvIZsxasSI0cOhuROhtWhnPXK0/lj6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/file-utils": "1.12.2",
-        "@zag-js/i18n-utils": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/file-utils": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.12.2.tgz",
-      "integrity": "sha512-E28mzjlG53RyApOGrc+gELXcrUpm6lIyWTo0ScJ7Nqlu5fe2Cy69bHyULECz3cI7/XK454yRA5Le7DifbyJQwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/i18n-utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/floating-panel": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.12.2.tgz",
-      "integrity": "sha512-L7nxKWQEg4LB+FTwcqs5qlWaYJ8ZA3aDrZXtxqDtqltGeICAlV/0CkjwNhdX4DyGt4VLgLLYqE3Ciq0tJ1PO9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/rect-utils": "1.12.2",
-        "@zag-js/store": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/focus-trap": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.12.2.tgz",
-      "integrity": "sha512-YhlkuxvRcmVhWZa08GqGbqkbL2M0Ae72+NVjoFhlpourgERsatJjvQ8SCx5SEpPcVQQc86Zh+4QAHrdQ4//20g==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2"
-      }
+    "node_modules/@zag-js/element-size": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
+      "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ==",
+      "license": "MIT"
     },
     "node_modules/@zag-js/focus-visible": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.12.2.tgz",
-      "integrity": "sha512-rXr8+ngjbSYDZDzpP3ckCvaqodvlOuIjfKYUnTYM717l5rYCIrn2vFF+ncDdelcWRBRv5nq7o79vjsqKU+1Bww==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
+      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.12.2"
+        "@zag-js/dom-query": "0.31.1"
       }
-    },
-    "node_modules/@zag-js/highlight-word": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/highlight-word/-/highlight-word-1.12.2.tgz",
-      "integrity": "sha512-M3bX0EeFZ5mh49B6IKTQKyPUZPMmO/7gImPr/1OmffUHUzr8EQT6M6WJBoDGB3dvGcPoahbNuGoZd3Jw48+1mA==",
-      "license": "MIT"
-    },
-    "node_modules/@zag-js/hover-card": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/hover-card/-/hover-card-1.12.2.tgz",
-      "integrity": "sha512-lxReLOp0kB6roMiZHz3yigKjqX541x9axIyWzwfeZmZ1Hqg46hoh5OYi0NclQ2zEFw6BMNLAc8ZVoWToBQSfTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/i18n-utils": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.12.2.tgz",
-      "integrity": "sha512-P3wuPeFXWC8LW+ZzSdmaRLsSDlrQT0FU7Sx3z4IkZXr8mV+QMg5fh95dmXNIDkEcG6zL7PHwt2ho80m/KuFcfA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/interact-outside": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.12.2.tgz",
-      "integrity": "sha512-ii7ZKufyF+kDr2WcwVgGZZQXrd/GmNYeJ4heR/RO7q3PxYv9le+GFq3evbtBhhVQ/0P3IqZZ8bZL0f/7qQyKKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/listbox": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.12.2.tgz",
-      "integrity": "sha512-EczE94iUzcKIqZhQ5SqaSiLkH88M+APrOp+xI+kHSDUt0SD4TQur6O/ALKFfBPT8Kip5iPK3Er5+t7PkC1wnvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/collection": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-visible": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/live-region": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.12.2.tgz",
-      "integrity": "sha512-yu1a7jKoheMmeiU4cYRqod2u7JiD1o7Cgi9af1PSBcU9vFJTUpIDJErRCI79vuPSugFvpP38Cjtc3LlgE3uGyA==",
-      "license": "MIT"
-    },
-    "node_modules/@zag-js/menu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.12.2.tgz",
-      "integrity": "sha512-Ja2RfNLHZOIBuSDRu7lS+0dfRfOov0xdA2RU8yZJBJupZBKT49tBEktJfWNr1YV3GDdlPoGSFVL2ogjNxtzDXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/rect-utils": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/number-input": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/number-input/-/number-input-1.12.2.tgz",
-      "integrity": "sha512-YesH2jaFwjRxfqdXUfjGgaAcLjoPPCYkltdC7wEBCNgAqU8UKZ+tktVHnfzZoLZiKqkQ9TXXOC4Ic6cmjXC2UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@internationalized/number": "3.6.1",
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/pagination": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.12.2.tgz",
-      "integrity": "sha512-5ly8eQg/58RV0blov46oZ5vhudWMxH+9rZw0LA6Hci3lGrmDjEezOkKmN0Om8PV+xoYcrCl0nnptxALChHCNSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/pin-input": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/pin-input/-/pin-input-1.12.2.tgz",
-      "integrity": "sha512-cRg4FOpL9wTGRztx+qk1Sx8aakXsGw7B8+AnboT12zcW64pYF72hqJUSrz13S2um7MhDJskPrdOetal4GBqWFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/popover": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.12.2.tgz",
-      "integrity": "sha512-wOYf4eNXWoZlBwNlF4EGYHsaGOrGsVIVVteCB/xSr9AXBrTF7CQiSwH445+m7u0KBZnDfsY61JweNx5U9FAmKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/aria-hidden": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-trap": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/remove-scroll": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/popper": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.12.2.tgz",
-      "integrity": "sha512-FoUx39kjStc7CUEtxCfcIlrQ0Oq9HH2As9HKz9b4IMwBg3u39sVP2XtHUQdHqNzMoscSsRtAqaTHMmRBz++GIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "1.6.13",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/presence": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/presence/-/presence-1.12.2.tgz",
-      "integrity": "sha512-V2oNmwe3qYXxAi9Cx1y+RAdb75fexJA+m0VgmO2R5tL4DIFA/CcHB5lc4yPxUzYw2fNwVZGd6F6eUX0Ys0Sp3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/progress": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.12.2.tgz",
-      "integrity": "sha512-B1jgP7iKYV3CwI33bnXPG4Hg7dr/9xl3FkYoM7hk8m5gD4b3zW1eJN8vQejKbARbxki0w/sv3r2DHCF14S7yMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/qr-code": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/qr-code/-/qr-code-1.12.2.tgz",
-      "integrity": "sha512-t5dByXkS3dBnhv2IS4GStAnVg0Ybm1gtWprspL97ndAHabE7tV1qwPaUV42cT16gFE6/l3aFtbjC+s0fVEFFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2",
-        "proxy-memoize": "3.0.1",
-        "uqr": "0.1.2"
-      }
-    },
-    "node_modules/@zag-js/radio-group": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.12.2.tgz",
-      "integrity": "sha512-4QsVREhwP0colnrsaWJIP1jjIZGqfKO7grh3K+gI4vmzD3hU9c2F6ZeRLdzdkDyK+CXcE9MYkDW0aJKxEsJr4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-visible": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/rating-group": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.12.2.tgz",
-      "integrity": "sha512-n6DJCdtu2hLhZDzFQd0iS7dXL0LJlCVVAFX1pPFrLAl1QQLDZLHftGZAsTnHpF2xAgrOyvzm1p+DPB5arQVcEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/react": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-1.12.2.tgz",
-      "integrity": "sha512-kjMP2ikLNbHSEhkrUkg20mtWyYzhOIIBMR4DXlS3nBnB2vNUGq71iUf45xgO7qq7jF/ANOazT5cKJkvBFzs7qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/core": "1.12.2",
-        "@zag-js/store": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/@zag-js/rect-utils": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.12.2.tgz",
-      "integrity": "sha512-GM1nRRsUDhlYULdouSQ/Hwow9Wy2dJUeK5qX/CruRkkkUKNkcAB97rv8oxZtTLBBa0KemD5X/JwY4W3rfY1mgw==",
-      "license": "MIT"
-    },
-    "node_modules/@zag-js/remove-scroll": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.12.2.tgz",
-      "integrity": "sha512-SYMGGlwnh2VCnae5pEcCgxhVqlCAquqclxp9KVbuypUIZ8Tby1cP78aWwQ5i9QgNGz5V1WfINsZaE0AFr++s0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/scroll-snap": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.12.2.tgz",
-      "integrity": "sha512-OCYEKKubAwshRI0PvVdt0W5vb7aq06xci5Z3mK3Fu3vIIZe1e1JVHC1vPfjJf4wso5vSdQBN9KLHgdoths4Fvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/dom-query": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/select": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/select/-/select-1.12.2.tgz",
-      "integrity": "sha512-kSa3EAkUxbEShRVnrkujujFTY22HK4aYSWl1F3u2Yqjmp9EJRX9kR1CXVXbDK8Ta9JmW82XPFyvIa+ah30isPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/collection": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/signature-pad": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/signature-pad/-/signature-pad-1.12.2.tgz",
-      "integrity": "sha512-xg5P8XRynjtpNU3KFET+Gw/pQpFj4yV+MnKHIX51Pb6JF8iCBkzx5lF6yNCp8y24ANG8ndGq8LCzv+sCC4tJnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2",
-        "perfect-freehand": "^1.2.2"
-      }
-    },
-    "node_modules/@zag-js/slider": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.12.2.tgz",
-      "integrity": "sha512-iAlV+A/PgJoCZaqsIAPBaTd7xDLHYbUe3QbjnDqmOHIVpRIV5kM1MH8creRFtDauHIh1xHD1TIvwKPVi6Ik6Xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/splitter": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/splitter/-/splitter-1.12.2.tgz",
-      "integrity": "sha512-YQLtL9AKiJtm2D7KLCvQGfHKtZ/FwikvABUW1ldUM2m1he6oKkKdGjSycT4yJg7+K5TbaZfV8jmc+bc7w0/5hA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/steps": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.12.2.tgz",
-      "integrity": "sha512-0bI8WYVQAiXOAn36i61Q+rqJzt6+cJK77q5/jMqDvlquQ2lvfhW2XXmBwYXmKadnmfiFprrCvGW1GGwSV/R82A==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/store": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.12.2.tgz",
-      "integrity": "sha512-Vy1QK0cmaaruzpkIwJ1lvCO3q0E0K/M1ZY71cDbEYKRYfpRqgV+7xluWbfTueqiAIYyGPa7+nCpakdr9zPPsnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "proxy-compare": "3.0.1"
-      }
-    },
-    "node_modules/@zag-js/switch": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.12.2.tgz",
-      "integrity": "sha512-vRKuCwYi5pDLgZMQ6I6cAzdLRFqC627aFycXRU1mC/0uVo/fCrrbjPvdaascLdmTtEq6/IvkjqZwQovedXbKyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-visible": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/tabs": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.12.2.tgz",
-      "integrity": "sha512-7IPumMCwJXP+ukU9AvnmpQJtUoMXbO+b4trG8kZeSGQps5VVZhUntrAOIZ6QYRv6psR1eoNo+4giTepr8dIt3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/tags-input": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.12.2.tgz",
-      "integrity": "sha512-bldiVV08yPCDVWGGmhCw4NbK44LuKT9SYYbGUtngRfABiiQUjvc8wQZNSdRgAV1ZXrniwLiMDsQ7L9pc585SRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/auto-resize": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/interact-outside": "1.12.2",
-        "@zag-js/live-region": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/time-picker": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/time-picker/-/time-picker-1.12.2.tgz",
-      "integrity": "sha512-dv4+ZDOWW7xOFNPQGqm2aMkuBLUkUaHCa/zTzV/0Ypl+A/6gBwjv81HIBDTJOHfhcJhlhuoZtgxU/n0ZRFB0yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      },
-      "peerDependencies": {
-        "@internationalized/date": ">=3.0.0"
-      }
-    },
-    "node_modules/@zag-js/timer": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/timer/-/timer-1.12.2.tgz",
-      "integrity": "sha512-1cmdgRSuZNKEoyv5CNb4GZeU3MUi+WJBMZKeXMWy4niBz5sheaLl1FqfW9vUnXAKpfqKif/OFj/QYeo9+m8LqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/toast": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.12.2.tgz",
-      "integrity": "sha512-uaSlF3PiQ/hlFamBRkrxUESDYd8vXo/iRqvNiROy18bBygpvhfNIi+f8vrvkGXuSqzZ8VWJbbgiNMtqPX6I/8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/toggle": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/toggle/-/toggle-1.12.2.tgz",
-      "integrity": "sha512-AUDEVjZtXwwYFSEHF4cDTJlGvjsaYcXdk3P7j9JQLoKkDci3x25QgOw6W670/RWpFNpbfjO8qBjWMs1P5+Dw4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/toggle-group": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.12.2.tgz",
-      "integrity": "sha512-pFgU9OjhcBVIWS5izSlTG+K3MlKK+LeD1qKaMIHvX//0pJWkn9oEcNVs58Ae4DrizN5A8WB5i5FjV7BC3hDNYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/tooltip": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.12.2.tgz",
-      "integrity": "sha512-RAZ0wslbHWfcH1MPVmfwFJfP3vzQ2Cf5hc5oJZzTURhNpgM3vIhtbCyjXwal/L82eW+Iu2bRrezE/fNRjwBIbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-visible": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/store": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/tour": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/tour/-/tour-1.12.2.tgz",
-      "integrity": "sha512-3TNE2p/mUe52RgndOpoSEVlB57TWuK6dM1X/atVMfDBDDBwTjDFkw5OnHSh3nDugva54EJVArn/0+9QGZhvl+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dismissable": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/focus-trap": "1.12.2",
-        "@zag-js/interact-outside": "1.12.2",
-        "@zag-js/popper": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/tree-view": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.12.2.tgz",
-      "integrity": "sha512-S/+a6KCFGSocMKlMG8GmfEkfjbuDeams4s/NTy1JYOTlYO72J5T0L9FD8i9q/bXBhHNno985b5QGpjlfHG6Brg==",
-      "license": "MIT",
-      "dependencies": {
-        "@zag-js/anatomy": "1.12.2",
-        "@zag-js/collection": "1.12.2",
-        "@zag-js/core": "1.12.2",
-        "@zag-js/dom-query": "1.12.2",
-        "@zag-js/types": "1.12.2",
-        "@zag-js/utils": "1.12.2"
-      }
-    },
-    "node_modules/@zag-js/types": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.12.2.tgz",
-      "integrity": "sha512-coJfIU/1Cg1RkWEkf4ArXK6rD3EU+lwxQdtVRlhvGk4c2ts2YTqNi/Sis5CT4/dzaKAk3pk8O2H3ry4IcL2tsg==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "3.1.3"
-      }
-    },
-    "node_modules/@zag-js/utils": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.12.2.tgz",
-      "integrity": "sha512-JLmzHzJVggOy+4z3jbJ8v86O6Gqm4h1/+ExtwfiTiba0O7j2+4Had7XQxSjVw+H7fNDAfwbZY8af7XzrnumcLQ==",
-      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -2707,6 +1810,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -2902,11 +2017,19 @@
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -2976,6 +2099,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
     "node_modules/dir-glob": {
@@ -3306,12 +2435,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3438,6 +2561,61 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/focus-lock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.12.1.tgz",
+      "integrity": "sha512-PFw4/GCREHI2suK/NlPSUxd+x6Rkp80uQsfCRFSOQNrm5pZif7eGtmG1VaD/UF1fW9tRBy5AaS77StatB3OJDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-dom": "^12.12.1",
+        "motion-utils": "^12.12.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framesync": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "license": "0BSD"
+    },
     "node_modules/fs-extra": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
@@ -3485,6 +2663,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/gh-pages": {
@@ -3835,6 +3022,18 @@
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3898,6 +3097,23 @@
         "node": "*"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.12.1.tgz",
+      "integrity": "sha512-GXq/uUbZBEiFFE+K1Z/sxdPdadMdfJ/jmBALDfIuHGi0NmtealLOfH9FqT+6aNPgVx8ilq0DtYmyQlo6Uj9LKQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-utils": "^12.12.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
+      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3936,6 +3152,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4061,12 +3286,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/perfect-freehand": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.2.tgz",
-      "integrity": "sha512-eh31l019WICQ03pkF3FSzHxB8n07ItqIQ++G5UV8JX0zVOXzgTGCqnRR0jJ2h9U8/2uW4W4mtGJELt9kEV0CFQ==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4195,19 +3414,15 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/proxy-compare": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
-      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
-      "license": "MIT"
-    },
-    "node_modules/proxy-memoize": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
-      "integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
       "dependencies": {
-        "proxy-compare": "^3.0.0"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/punycode": {
@@ -4250,6 +3465,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+      "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -4260,6 +3487,35 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.6.tgz",
+      "integrity": "sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^1.3.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-icons": {
@@ -4285,6 +3541,75 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.0.tgz",
+      "integrity": "sha512-sGsQtcjMqdQyijAHytfGEELB8FufGbfXIsvUTe+NLx1GDRJCXtCFLBLUI1eyZCKXXvbEU2C6gai0PZKoIE9Vbg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -4584,6 +3909,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
+    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -4667,12 +3998,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uqr": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
-      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
-      "license": "MIT"
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4681,6 +4006,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",
-    "@chakra-ui/react": "^3.19.1",
+    "@chakra-ui/react": "^2.10.9",
     "@chakra-ui/theme": "^3.4.6",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/src/NimishCV.jsx
+++ b/src/NimishCV.jsx
@@ -7,19 +7,19 @@ import {
 } from '@chakra-ui/react';
 import {
   EmailIcon, PhoneIcon, LinkIcon, CalendarIcon,
-  StarIcon, CodeIcon, CheckCircleIcon, ExternalLinkIcon
+  StarIcon, CheckCircleIcon, ExternalLinkIcon
 } from '@chakra-ui/icons';
-import { FaGithub, FaLinkedin, FaSun, FaMoon, FaDownload, FaUserTie, FaCertificate, FaGraduationCap, FaCheckCircle, FaLocationDot, FaMusic, FaCode, FaUniversity, FaCalendar, FaBook, FaChalkboardTeacher, FaUser } from 'react-icons/fa';
+import { FaGithub, FaLinkedin, FaSun, FaMoon, FaDownload, FaUserTie, FaCertificate, FaGraduationCap, FaCheckCircle, FaMapMarkerAlt, FaMusic, FaCode, FaUniversity, FaCalendar, FaBook, FaChalkboardTeacher, FaUser, FaBriefcase } from 'react-icons/fa';
 
 const sectionIcons = {
   contact: <PhoneIcon />,
   social: <LinkIcon />,
   soft: <StarIcon />,
-  lang: <CodeIcon />,
+  lang: <Icon as={FaCode} />,
   interests: <CheckCircleIcon />,
   profile: <Icon as={FaUserTie} />,
   work: <Icon as={FaBriefcase} />,
-  skills: <CodeIcon />,
+  skills: <Icon as={FaCode} />,
   cert: <Icon as={FaCertificate} />,
   edu: <Icon as={FaGraduationCap} />,
 };
@@ -235,7 +235,7 @@ const NimishCV = () => {
                 <Text>{personalInfo.email}</Text>
               </HStack>
               <HStack>
-                <Icon as={FaLocationDot} />
+                <Icon as={FaMapMarkerAlt} />
                 <Text>{personalInfo.location}</Text>
               </HStack>
               <HStack>
@@ -425,7 +425,7 @@ const NimishCV = () => {
                   <Text fontWeight="medium">{edu.institution}</Text>
                 </HStack>
                 <HStack mb={3} color="gray.500" fontSize="sm">
-                  <Icon as={FaLocationDot} />
+                  <Icon as={FaMapMarkerAlt} />
                   <Text>{edu.location}</Text>
                   <Icon as={FaCalendar} ml={4} />
                   <Text>{edu.period}</Text>


### PR DESCRIPTION
This pull request fixes #3.

The issue describes a problem where the GitHub Pages website shows no output, suggesting a build issue. The changes made in the patch address this by:

1.  **Correcting relative paths in `index.html`**: The `href` for the favicon and `src` for the main JavaScript file were changed from `/vite.svg` and `/src/main.jsx` to `./vite.svg` and `./src/main.jsx` respectively. This is a common fix for GitHub Pages, as absolute paths (starting with `/`) often don't work correctly when the site is hosted in a subdirectory (like `username.github.io/repository-name/`). Using relative paths ensures that these assets are correctly located regardless of the base URL.
2.  **Downgrading `@chakra-ui/react`**: The `package.json` and `package-lock.json` files show a downgrade of `@chakra-ui/react` from `^3.19.1` to `^2.10.9`. This suggests a potential compatibility issue with the newer version that might have been causing the build or rendering to fail. Downgrading to a known stable version could resolve such conflicts.
3.  **Updating `react-icons` imports and usage**: The `NimishCV.jsx` file had `CodeIcon` and `LocationDot` icons that were either removed from `react-icons` or had their names changed. The patch updates these to `FaCode` and `FaMapMarkerAlt` respectively, and wraps `FaCode` in an `Icon` component from Chakra UI, ensuring the icons render correctly. It also adds `FaBriefcase` for the work section. These changes fix potential rendering errors due to incorrect icon imports or usage.

The last message from the AI agent, "Command `npm run build` executed with exit code 0," indicates that the project now builds successfully, which is a crucial step towards resolving the "no output" issue on GitHub Pages. The combination of path corrections, dependency adjustments, and icon fixes directly addresses common causes of blank pages or build failures in web projects hosted on GitHub Pages.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌